### PR TITLE
fix(theme/main.css main.sass): fit any menu length

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -355,8 +355,9 @@ div#masthead nav#menu {
   }
 }
 div#masthead nav#menu#menu.active {
-  max-height: 15em;
+  max-height: 100%;
   padding: 2em 0;
+  overflow: visible;
 }
 div#masthead nav#menu ul {
   border-top: 1px solid #808080;


### PR DESCRIPTION
Issue: when the number of items in a menu exceed four, menu items are hidden and won't display 
Fix: set #nav#menu.active overflow: visible and max-height: 100%