### PR TITLE
fix(templates/base.html): strip dash in menu title

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -86,7 +86,7 @@
                 <ul>
                     {% if DISPLAY_PAGES_ON_MENU %}
                       {% for p in pages %}
-                        <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.slug }}</a></li>
+                        <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.slug | replace('-', ' ') }}</a></li>
                       {% endfor %}
                     {% endif %}
                     {% for title, link in MENUITEMS %}


### PR DESCRIPTION
Issue: Slugs with more than one word have hyphens between words in slug
Fix: strip using jinja filters if present